### PR TITLE
chore: normalize MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,34 +1,21 @@
-**MIT License**
+MIT License
 
-Copyright 2017 John P Didion
+Copyright (c) 2017 John Didion
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the "Software"), to deal in 
-the Software without restriction, including without limitation the rights to 
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
-of the Software, and to permit persons to whom the Software is furnished to do 
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO E
-VENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR 
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-THE SOFTWARE.
-
-**Copyrighted Works**
-This software may use copyrighted and/or public domain works and distributes 
-these works under the terms of their respective licenses. All copyright 
-restrictions still apply to these 'third-party' packages. Furthermore, xphyle is 
-a community project with contributors within and outside of the US Government; 
-these authors retain copyright on their work, which they may relinquish via a
-public domain dedication. Below is a list of contributors, and either the 
-license under which their work is governed, or the release of copyright under
-public domain dedication.
-
-**List of Contributors**
-John P Didion   2016-2017   Public Domain
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
**Note:** This MR was largely generated by Claude and has not been completely reviewed by me (the human). You should feel free to defer your review until this warning has been removed.

## Summary
Replaces the existing LICENSE file with standard MIT text so the SPDX detector recognizes the license.

The previous file wrapped `MIT License` in markdown bold (`**MIT License**`), which prevents GitHub from detecting the SPDX identifier, and contained a bespoke "Copyrighted Works / Contributors" tail that isn't required for MIT.

This is part of a baseline-settings pass across all active `jdidion/*` repos.

## Test plan
- [ ] Confirm the license is detected as MIT on the repo landing page after merge.