### PR TITLE
Fix #112: tolerate empty compressed files on the system read path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Fix #112 - Reading an empty compressed file via a system-level decompressor (gzip/pigz) no longer raises a spurious `EOFError`. System decompressors exit non-zero on empty input, which surfaced as a nondeterministic failure depending on a process-exit race (more frequent on single-CPU machines).
+
 ## v4.4.1 (2020.12.06)
 
 * Fix #41 - Windows does not support SIGPIPE

--- a/tests/test_xphyle.py
+++ b/tests/test_xphyle.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, skipIf
 from . import *
 import gzip
+import os
 from io import BytesIO, IOBase
 from xphyle import *
 from xphyle.paths import TempDir, STDIN, STDOUT, STDERR, EXECUTABLE_CACHE
@@ -194,8 +195,15 @@ class XphyleTests(TestCase):
         with self.assertRaises(IOError):
             xopen("foobar", "r")
         path = self.root.make_file(suffix=".gz")
+        # Write a real gzip stream so the read path decompresses actual data
+        # rather than an empty file (see issue #112: system decompressors exit
+        # non-zero on empty input, which made this test fail nondeterministically
+        # depending on a process-exit race).
+        with gzip.open(path, "wt") as o:
+            o.write("bar")
         with xopen(path, "rU", context_wrapper=True) as i:
             assert "rt" == i.mode
+            assert i.read() == "bar"
         with xopen(path, "w", compression=True, context_wrapper=True) as o:
             assert cast(FileLikeWrapper, o).compression == "gzip"
             o.write("foo")
@@ -210,6 +218,19 @@ class XphyleTests(TestCase):
         with self.assertRaises(ValueError):
             with xopen(existing_file, "wt", overwrite=False):
                 pass
+
+    def test_xopen_empty_compressed_file(self):
+        # Regression test for issue #112: reading an empty (zero-byte)
+        # compressed file via the system-level decompressor must not raise.
+        # System tools such as gzip/pigz exit non-zero on empty input, which
+        # previously surfaced as a nondeterministic EOFError depending on a
+        # process-exit race (failing far more often on single-CPU machines).
+        path = self.root.make_file(suffix=".gz")
+        assert os.path.getsize(path) == 0
+        # Force the system-level read path and consume the whole stream so the
+        # subprocess exit code is deterministically checked.
+        with xopen(path, "rb", use_system=True, context_wrapper=True) as i:
+            assert i.read() == b""
 
     def test_xopen_fileobj(self):
         path = self.root.make_file(suffix=".gz")

--- a/xphyle/formats.py
+++ b/xphyle/formats.py
@@ -195,13 +195,27 @@ class SystemReader(SystemIO):
     def _raise_if_error(self) -> None:
         """Raise EOFError if process is not running anymore and the
         exit code is nonzero.
+
+        An empty source file is a special case: system decompressors such as
+        ``gzip``/``pigz`` exit non-zero on empty input ("unexpected end of
+        file"), whereas the Python implementations treat an empty file as a
+        valid, empty stream. To keep the system- and library-level read paths
+        consistent, a non-zero exit code is ignored when the source file is
+        empty.
         """
         retcode = self.process.poll()
-        if retcode is not None and retcode != 0:  # pragma: no-cover
+        if retcode is not None and retcode != 0 and not self._source_is_empty():
             raise EOFError(
                 f"{self.executable_name} process returned non-zero exit code "
                 f"{retcode}. Is the input file truncated or corrupt?"
             )
+
+    def _source_is_empty(self) -> bool:
+        """Return True if the source file exists and is zero bytes."""
+        try:
+            return os.path.getsize(self._name) == 0
+        except OSError:  # pragma: no-cover
+            return False
 
     def read(self, *args) -> bytes:
         """Read bytes from the stream. Arguments are passed through to the


### PR DESCRIPTION
**Note:** This MR was largely generated by Claude and has not been completely reviewed by me (the human). You should feel free to defer your review until this warning has been removed.

Fixes #112.

## Root cause

Reading an empty (zero-byte) compressed file routes through `SystemReader`, which spawns `gzip`/`pigz` to decompress. System decompressors exit non-zero on empty input (`gzip: unexpected end of file`, `pigz: skipping: ... empty`), unlike Python's `gzip` module, which treats an empty file as a valid empty stream.

`SystemReader._raise_if_error()` turned that exit code into an `EOFError`. Whether it fired depended on a race between the parent's `process.poll()` and the child process exiting, so the failure showed up nondeterministically and far more often on single-CPU machines, which is exactly what @sanvila observed (reproducible with `nr_cpus=1`).

## Fix

- `SystemReader._raise_if_error()` suppresses a non-zero exit code when the source file is empty (0 bytes), aligning the system-decompressor read path with the Python read path. Genuine truncation or corruption of a non-empty file still raises.
- `test_xopen_file` now writes a real gzip stream before reading, so it no longer depends on the empty-file race.
- New `test_xopen_empty_compressed_file` forces the system read path on an empty `.gz` and reads to completion. It is deterministic (no race): it fails on the pre-fix code with the same `EOFError` from the issue and passes with the fix.

## Verification

`pytest -m "not perf"` (the selector the Debian build uses): 143 passed, 3 skipped, 29 subtests passed. No regressions (+1 vs. the prior 142, the new regression test). Reproduced locally with GNU `gzip`, which also exits 1 on empty input.

@sanvila could you confirm this resolves the build failure on your single-CPU setup? Thanks for the detailed report.
